### PR TITLE
configassume_sslをtrueに

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = false


### PR DESCRIPTION
This pull request includes a change to the `config/environments/production.rb` file, which assumes all access to the app is happening through an SSL-terminating reverse proxy.

* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL50-R50): Enabled the `assume_ssl` configuration by setting `config.assume_ssl = true`.