### PR TITLE
cable.ymlを編集。接続先をupstushに明示

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= Rails.application.credentials.dig(:redis_url) %>
   channel_prefix: myapp_production


### PR DESCRIPTION
This pull request includes a change to the `config/cable.yml` file to enhance security by using Rails credentials for the Redis URL.

Security improvement:

* [`config/cable.yml`](diffhunk://#diff-661620ae7be69a63f01b319f70bb6e3e0f6183b59258e9ed7aee623d75f17d90L9-R9): Changed the `url` configuration to use `Rails.application.credentials.dig(:redis_url)` instead of fetching the environment variable directly.