### PR TITLE
ogpのパスを指定しました。加えて、rubocopを導入しました。

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,55 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/**/*"
+    - "bin/*"
+    - "node_modules/**/*"
+    - "config/initializers/devise.rb"
+    - "config/environments/*.rb"
+    - "Gemfile"
+  NewCops: enable
 
-# Overwrite or add rules to create your own house style
-#
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+Gemspec/DevelopmentDependencies:
+  Enabled: true
+Gemspec/RequireMFA:
+  Enabled: true
+Layout/LineContinuationSpacing:
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+Lint/AmbiguousRange:
+  Enabled: true
+Lint/ConstantOverwrittenInRescue:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: true
+  AllowMultipleReturnValues: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - "config/routes.rb"
+
+Metrics/MethodLength:
+  Max: 40
+
+Metrics/AbcSize:
+  Max: 40
+

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "rubocop", require: false
+  gem "solargraph"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -121,6 +122,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.1)
     faraday (2.12.2)
@@ -146,12 +148,17 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.4)
     logger (1.6.5)
     loofah (2.24.0)
@@ -185,6 +192,7 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    observer (0.1.2)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -241,6 +249,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rbs (3.8.1)
+      logger
     rdoc (6.11.0)
       psych (>= 4.0.0)
     redis (5.3.0)
@@ -262,6 +272,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    reverse_markdown (3.0.0)
+      nokogiri
     rexml (3.4.0)
     rubocop (1.71.0)
       json (~> 2.3)
@@ -303,6 +315,24 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    solargraph (0.51.2)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      jaro_winkler (~> 1.6)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      logger (~> 1.6)
+      observer (~> 0.1)
+      ostruct (~> 0.6)
+      parser (~> 3.0)
+      rbs (~> 3.0)
+      reverse_markdown (>= 2.0, < 4)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -315,6 +345,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.2)
     thor (1.3.2)
+    tilt (2.6.0)
     timeout (0.4.3)
     turbo-rails (2.0.11)
       actionpack (>= 6.0.0)
@@ -340,6 +371,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -362,8 +394,10 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.1)
   redis
   redis-actionpack
+  rubocop
   rubocop-rails-omakase
   selenium-webdriver
+  solargraph
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: %i[ show edit update destroy ]
-  before_action :authenticate_user!, only: %i[ create destroy ]
+  before_action :set_post, only: %i[show edit update destroy]
+  before_action :authenticate_user!, only: %i[create destroy]
 
   # GET /posts or /posts.json
   def index
@@ -21,7 +21,7 @@ class PostsController < ApplicationController
   # GET /posts/1/edit
   def edit
     if current_user?(@post.user)
-      render "edit"
+      render 'edit'
     else
       redirect_to post_path(@post), notice: "You can't edit this post"
     end
@@ -31,7 +31,7 @@ class PostsController < ApplicationController
     if signed_in?
       @liked_posts = current_user.liked_posts
     else
-      redirect_to new_user_session_path, notice: "You need to sign in to see your liked posts"
+      redirect_to new_user_session_path, notice: 'You need to sign in to see your liked posts'
     end
   end
 
@@ -43,15 +43,15 @@ class PostsController < ApplicationController
 
     if @post.save
       @post.broadcast_prepend_to(
-        "posts_likes_channel",
-        partial: "posts/broadcast_first_post_content",
+        'posts_likes_channel',
+        partial: 'posts/broadcast_first_post_content',
         locals: {
           post: @post
         }
       )
-      flash.now[:notice] = "Post was successfully created."
+      flash.now[:notice] = 'Post was successfully created.'
     else
-      flash.now[:alert] = "Post was not created."
+      flash.now[:alert] = 'Post was not created.'
     end
   end
 
@@ -59,7 +59,7 @@ class PostsController < ApplicationController
   def update
     respond_to do |format|
       if @post.update(post_params)
-        format.html { redirect_to @post, notice: "Post was successfully updated." }
+        format.html { redirect_to @post, notice: 'Post was successfully updated.' }
         format.json { render :show, status: :ok, location: @post }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -72,23 +72,23 @@ class PostsController < ApplicationController
   def destroy
     @post.destroy!
 
-    @post.broadcast_remove_to("posts_channel")
+    @post.broadcast_remove_to('posts_channel')
     redirect_to posts_path, notice: 'Post was successfully destroyed.'
-
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_post
-      @post = Post.find(params[:id])
-    end
 
-    # Only allow a list of trusted parameters through.
-    def post_params
-      params.require(:post).permit(:name, :body, :image, :url)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_post
+    @post = Post.find(params[:id])
+  end
 
-    def current_user?(user)
-      user == current_user
-    end
+  # Only allow a list of trusted parameters through.
+  def post_params
+    params.require(:post).permit(:name, :body, :image, :url)
+  end
+
+  def current_user?(user)
+    user == current_user
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,14 +15,14 @@ module ApplicationHelper
         description: :description,
         type: 'website',
         url: request.original_url,
-        image: image_url('/assets/images/ogp.png'), # 配置するパスやファイル名によって変更すること
+        image: image_url('ogp.png'), # 配置するパスやファイル名によって変更すること
         local: 'ja-JP'
       },
       # Twitter用の設定を個別で設定する
       twitter: {
         card: 'summary_large_image', # Twitterで表示する場合は大きいカードにする
         site: '@', # アプリの公式Twitterアカウントがあれば、アカウント名を書く
-        image: image_url('/assets/images/ogp.png') # 配置するパスやファイル名によって変更すること
+        image: image_url('ogp.png') # 配置するパスやファイル名によって変更すること
       }
     }
   end


### PR DESCRIPTION
This pull request includes several changes to the project's configuration and codebase, focusing on RuboCop configuration updates, gem additions, and string formatting consistency.

### Configuration updates:

* [`.rubocop.yml`](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL1-R55): Updated the RuboCop configuration to include new cops and enable/disable specific rules. Added exclusions for certain directories and files.
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR53-R54): Added `rubocop` and `solargraph` gems to the development group.

### Codebase changes:

* [`app/controllers/posts_controller.rb`](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL24-R24): Standardized string literals to use single quotes instead of double quotes in multiple methods (`edit`, `liked`, `create`, `update`, `destroy`). [[1]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL24-R24) [[2]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL34-R34) [[3]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL46-R62) [[4]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL75-R80)
* [`app/helpers/application_helper.rb`](diffhunk://#diff-5f3fc5e3977d242572aa1d08551f5eb557de0ccaff30370838ee9df5386ea0daL18-R25): Updated image paths in the `default_meta_tags` method to remove the `/assets/images/` prefix.