### PR TITLE
fix:first_postのURLが長い場合短縮するようにしました。

### DIFF
--- a/app/views/posts/show_post/_first_post_content.html.erb
+++ b/app/views/posts/show_post/_first_post_content.html.erb
@@ -41,7 +41,7 @@
           <p class="text-lg font-semibold">
           <strong>参考URL:</strong>
           <div class="flex justify-center">
-            <a href="<%= post.url %>" class="text-indigo-500 underline" target="_blank"><%= post.url %></a>
+            <a href="<%= post.url %>" class="text-indigo-500 underline truncate" target="_blank"><%= post.url %></a>
           </div>
           </p>
         <% end %>


### PR DESCRIPTION
This pull request makes a small change to the `app/views/posts/show_post/_first_post_content.html.erb` file to improve the display of URLs.

* Added the `truncate` class to the URL link to ensure that long URLs are truncated and do not overflow the container.