### PR TITLE
投稿一覧ページの表示件数とレイアウトの変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   # GET /posts or /posts.json
   def index
-    @posts = Post.page(params[:page]).order(created_at: :desc).per(12)
+    @posts = Post.page(params[:page]).order(created_at: :desc).per(9)
     @post = Post.new
   end
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -34,7 +34,7 @@
 
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
-    <div id="posts" class="grid gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4 xl:gap-8">
+    <div id="posts" class="grid gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 ">
       <!-- article - start -->
       <% @posts.each do |post| %>
         <%= render "post", post: post %>


### PR DESCRIPTION
- app/controllers/posts_controller.rb:
  - 投稿一覧ページの表示件数を12件から9件に変更
- app/views/posts/index.html.erb:
  - 投稿一覧ページのグリッドレイアウトを調整し、xl:grid-cols-4を削除